### PR TITLE
Fixed fromstring for Python3

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -176,7 +176,7 @@ def fromstring(s):
   """ Parse text string and return PatchSet()
       object (or False if parsing fails)
   """
-  ps = PatchSet( StringIO(s) )
+  ps = PatchSet( StringIO(s.encode()) )
   if ps.errors == 0:
     return ps
   return False


### PR DESCRIPTION
In python3 if you pass a string to fromstring(s) method it fails because:

**TypeError: 'str' does not support the buffer interface**

The str has to be encoded to bytes before instance a PatchSet