### PR TITLE
Return an error when aborting due to existing .orig file (fixes #60)

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -940,6 +940,7 @@ class PatchSet(object):
         backupname = filename+b".orig"
         if exists(backupname):
           warning("can't backup original file to %s - aborting" % backupname)
+          errors += 1
         else:
           import shutil
           shutil.move(filename, backupname)


### PR DESCRIPTION
Using the same setup as describe in #60:

```
$ ./patch.py --debug working.patch || echo Failed
   DEBUG reading working.patch
   DEBUG crlf: 0  lf: 5  cr: 0	 - file: b.txt hunk: 1
   DEBUG -  1 hunks for a.txt
   DEBUG total files: 1  total hunks: 1
   DEBUG normalize filenames
   DEBUG     patch type = plain
   DEBUG     source = a.txt
   DEBUG     target = b.txt
   DEBUG processing 1/1:	 a.txt
   DEBUG  hunk no.1 for file a.txt  -- is ready to be patched
 WARNING can't backup original file to a.txt.orig - aborting
Failed
```