### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,12 @@ python:
   - "3.7"
   - "3.7-dev"
   - "3.8-dev"
-
+  
+os: linux
+arch:
+  - amd64
+  - arm64
+  
 install:
   - pip install coverage
   - pip install pypack


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI.