### PR TITLE
Minimal changes to make it work with py3 with log and all

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -62,6 +62,8 @@ def tostr(b):
 
 logger = logging.getLogger(__name__)
 
+logger.handlers.clear() # really needed? maybe for use as library...
+
 debug = logger.debug
 info = logger.info
 warning = logger.warning
@@ -697,8 +699,8 @@ class PatchSet(object):
     for i,p in enumerate(self.items):
       if debugmode:
         debug("    patch type = " + p.type)
-        debug("    source = " + p.source)
-        debug("    target = " + p.target)
+        debug("    source = " + tostr(p.source))
+        debug("    target = " + tostr(p.target))
       if p.type in (HG, GIT):
         # TODO: figure out how to deal with /dev/null entries
         debug("stripping a/ and b/ prefixes")
@@ -1157,6 +1159,7 @@ def main():
   loglevel = verbosity_levels[options.verbosity]
   logformat = "%(message)s"
   logger.setLevel(loglevel)
+  logger.addHandler(streamhandler)
   streamhandler.setFormatter(logging.Formatter(logformat))
 
   if options.debugmode:


### PR DESCRIPTION
Made the minimal amount of changes to make it work for python 3.8.0, should work fine in all python 3, can't test in python 2 (my initial idea was to strip out py2 support and make it a small tool, I just use it as __main__).

Fixed:
- No log (NullHandler made it so it has a handler, having as effect to not use the default one, circumvented by actually setting also the streamhandler in main).
- Debug crash (by simply calling tostr when objects are bytes in log statements)

Hope this gets tested in py2 and up in pip so I can start using it from the repo instead of shipping it (command line patch tools for windows are a rarity unfortunately).
